### PR TITLE
Added s-param to UserDefined2ResizeMT

### DIFF
--- a/ResampleMT - Readme.txt
+++ b/ResampleMT - Readme.txt
@@ -18,7 +18,7 @@ GaussResizeMT
 SincResizeMT
 SinPowResizeMT (same parameters than Gauss, default param 2.5)
 SincLin2ResizeMT (same parameters than Sinc, default param 15)
-UserDefined2ResizeMT (Same parameters as BicubicResize)
+UserDefined2ResizeMT (Same parameters as BicubicResize and s)
   Control values are b and c as floats in range -50..250. 
   Default values are b=121, c=19. b and c parameters are 2 and 3 members of impulse response of filter defined at +-2 samples
   range. Middle (first) member = 1.0, i.e. 235 in 8bit video limited range encoding. To view how it contol sharpness and ringing
@@ -26,12 +26,19 @@ UserDefined2ResizeMT (Same parameters as BicubicResize)
   to 6 and 7 samples started from 1st from the left. Samples values input and processing or 3 and 4 are interconneted internally to 
   represent actual filter procesing. Curve at the graph represent resulted symmetrical impulse responce.
   Mouse cursor and dragging for sliders may be used to set samples values.
+  s (support) param - controls the 'support' of filter to use by resampler engine. Float value in valid range from
+  1.5 to 15. Default 2.3. Allow to finetune resampling result between partially non-linear but more sharper and less
+  residual ringing (at low b and c values) and more linear processing with wider 'peaking' used. Setting too high 
+  in common use cases (about > 5) may visibly degrade resampler performance (fps) witout any visible output changes.
+  Recommended adjustment range - between 2 and 3.  
   Examples: 
   b=126 c=22 - medium soft, almost no ringing.
   b=102 c=2 - sharper, small local peaking.
-  b=68 c=-30 - more sharper, stronger local peaking.
+  b=70 c=-30 s=2 - sharper, thinner 'peaking'.
+  b=70 c=-30 s=2.5 - a bit softer, more thick 'peaking'. 
   b=82 c=20 - sharp but lots of far ringing. Not for using.
   Recommended b,c values for UserDefined2Resize and more in bc_rec.png and bcde_rec.png.
+
 
 
 Parameters are exactly the same than the orignal resampling functions, and in the same order, so they are totaly

--- a/ResampleMT/resample.cpp
+++ b/ResampleMT/resample.cpp
@@ -5061,10 +5061,14 @@ AVSValue __cdecl FilteredResizeMT::Create_SincLin2Resize(AVSValue args, void*, I
 
 AVSValue __cdecl FilteredResizeMT::Create_UserDefined2Resize(AVSValue args, void*, IScriptEnvironment* env)
 {
-	UserDefined2Filter f(args[3].AsFloat(121.0),args[4].AsFloat(19.0));
-	return CreateResize(args[0].AsClip(),args[1].AsInt(),args[2].AsInt(),args[9].AsInt(0),
+	UserDefined2Filter f(args[3].AsFloat(121.0),args[4].AsFloat(19.0), args[5].AsFloat(2.3));
+/*	return CreateResize(args[0].AsClip(),args[1].AsInt(),args[2].AsInt(),args[9].AsInt(0),
 		args[10].AsBool(true),args[11].AsBool(true),args[12].AsBool(false),args[13].AsBool(false),
-		args[14].AsInt(0),args[15].AsInt(1),false,0,0,args[16].AsInt(6),&args[5],&f,env);
+		args[14].AsInt(0),args[15].AsInt(1),false,0,0,args[16].AsInt(6),&args[5],&f,env);*/
+	return CreateResize(args[0].AsClip(),args[1].AsInt(),args[2].AsInt(),args[10].AsInt(0),
+			args[11].AsBool(true),args[12].AsBool(true),args[13].AsBool(false),args[14].AsBool(false),
+			args[15].AsInt(0),args[16].AsInt(1),false,0,0,args[17].AsInt(6),&args[6],&f,env);
+
 }
 
 // Desample functions
@@ -5179,11 +5183,15 @@ AVSValue __cdecl FilteredResizeMT::Create_DeSincLin2Resize(AVSValue args, void*,
 
 AVSValue __cdecl FilteredResizeMT::Create_DeUserDefined2Resize(AVSValue args, void*, IScriptEnvironment* env)
 {
-  UserDefined2Filter f(args[3].AsFloat(121.0f),args[4].AsFloat(19.0f));
-  return CreateResize(args[0].AsClip(),args[1].AsInt(),args[2].AsInt(),args[9].AsInt(0),
+  UserDefined2Filter f(args[3].AsFloat(121.0f),args[4].AsFloat(19.0f),args[5].AsFloat(2.3f));
+/*  return CreateResize(args[0].AsClip(),args[1].AsInt(),args[2].AsInt(),args[9].AsInt(0),
 	  args[10].AsBool(true),args[11].AsBool(true),args[12].AsBool(false),args[13].AsBool(false),
 	  args[14].AsInt(0),args[15].AsInt(1),true,args[16].AsInt(0),args[17].AsInt(0),args[18].AsInt(6),
-	  &args[5],&f,env);
+	  &args[5],&f,env);*/
+  return CreateResize(args[0].AsClip(),args[1].AsInt(),args[2].AsInt(),args[10].AsInt(0),
+		  args[11].AsBool(true),args[12].AsBool(true),args[13].AsBool(false),args[14].AsBool(false),
+		  args[15].AsInt(0),args[16].AsInt(1),true,args[17].AsInt(0),args[18].AsInt(0),args[19].AsInt(6),
+		  &args[6],&f,env);
 }
 
 
@@ -5225,7 +5233,7 @@ extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScri
 		"[logicalCores]b[MaxPhysCore]b[SetAffinity]b[sleep]b[prefetch]i[range]i[ThreadLevel]i",FilteredResizeMT::Create_SinPowerResize, 0);
 	env->AddFunction("SincLin2ResizeMT", "c[target_width]i[target_height]i[src_left]f[src_top]f[src_width]f[src_height]f[taps]i[threads]i" \
 		"[logicalCores]b[MaxPhysCore]b[SetAffinity]b[sleep]b[prefetch]i[range]i[ThreadLevel]i",FilteredResizeMT::Create_SincLin2Resize, 0);
-	env->AddFunction("UserDefined2ResizeMT", "c[target_width]i[target_height]i[b]f[c]f[src_left]f[src_top]f[src_width]f[src_height]f[threads]i" \
+	env->AddFunction("UserDefined2ResizeMT", "c[target_width]i[target_height]i[b]f[c]f[s]f[src_left]f[src_top]f[src_width]f[src_height]f[threads]i" \
 		"[logicalCores]b[MaxPhysCore]b[SetAffinity]b[sleep]b[prefetch]i[range]i[ThreadLevel]i", FilteredResizeMT::Create_UserDefined2Resize, 0);
 
 // Desample functions
@@ -5254,7 +5262,7 @@ extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScri
 		"[logicalCores]b[MaxPhysCore]b[SetAffinity]b[sleep]b[prefetch]i[range]i[accuracy]i[order]i[ThreadLevel]i",FilteredResizeMT::Create_DeSinPowerResize, 0);
 	env->AddFunction("DeSincLin2ResizeMT", "c[target_width]i[target_height]i[src_left]f[src_top]f[src_width]f[src_height]f[taps]i[threads]i" \
 		"[logicalCores]b[MaxPhysCore]b[SetAffinity]b[sleep]b[prefetch]i[range]i[accuracy]i[order]i[ThreadLevel]i",FilteredResizeMT::Create_DeSincLin2Resize, 0);
-	env->AddFunction("DeUserDefined2ResizeMT", "c[target_width]i[target_height]i[b]f[c]f[src_left]f[src_top]f[src_width]f[src_height]f[threads]i" \
+	env->AddFunction("DeUserDefined2ResizeMT", "c[target_width]i[target_height]i[b]f[c]f[s]f[src_left]f[src_top]f[src_width]f[src_height]f[threads]i" \
 		"[logicalCores]b[MaxPhysCore]b[SetAffinity]b[sleep]b[prefetch]i[range]i[accuracy]i[order]i[ThreadLevel]i",FilteredResizeMT::Create_DeUserDefined2Resize, 0);
 
 	return "ResizeMT plugin";	

--- a/ResampleMT/resample_functions.cpp
+++ b/ResampleMT/resample_functions.cpp
@@ -325,13 +325,14 @@ double SincLin2Filter::f(double value)
  *** UserDefined2 filter ***
  *********************************/
 
-UserDefined2Filter::UserDefined2Filter(double _b, double _c)
+UserDefined2Filter::UserDefined2Filter(double _b, double _c, double _s)
 {
     a = 1.0; // 0 sample = 1
     b = (double)clamp(_b, -50.0, 250.0); // 1 and -1  sample
     c = (double)clamp(_c, -50.0, 250.0); // 2 and -2 sample
     b = (b - 16.0) / 219.0;
     c = (c - 16.0) / 219.0;
+	s = (double)clamp(_s, 1.5, 15.0); // filter support for resampler
 }
 
 double UserDefined2Filter::sinc(double value)
@@ -349,12 +350,7 @@ double UserDefined2Filter::f(double x)
 {
     x = fabs(x);
 
-    if (x<=3) // ?
-    {
-        return c*sinc(x+2) + b*sinc(x+1) + a*sinc(x) + b*sinc(x-1) + c*sinc(x-2);
-    }
-    else return 0;
-
+    return c*sinc(x+2) + b*sinc(x+1) + a*sinc(x) + b*sinc(x-1) + c*sinc(x-2);
 }
 
 

--- a/ResampleMT/resample_functions.h
+++ b/ResampleMT/resample_functions.h
@@ -306,7 +306,7 @@ class UserDefined2Filter : public ResamplingFunction
 	 **/
 {
 public:
-	UserDefined2Filter(double _b = 121.0, double _c = 19.0, double _s = 2.2);
+	UserDefined2Filter(double _b = 121.0, double _c = 19.0, double _s = 2.3);
 	double f(double x);
 	double support() { return s; }
 

--- a/ResampleMT/resample_functions.h
+++ b/ResampleMT/resample_functions.h
@@ -306,13 +306,14 @@ class UserDefined2Filter : public ResamplingFunction
 	 **/
 {
 public:
-	UserDefined2Filter(double _b = 121.0, double _c = 19.0);
+	UserDefined2Filter(double _b = 121.0, double _c = 19.0, double _s = 2.2);
 	double f(double x);
-	double support() { return 2.0; }
+	double support() { return s; }
 
 private:
 	double sinc(double value);
 	double a, b, c;
+	double s; // variable support
 };
 
 #endif  // __Reample_Functions_H__


### PR DESCRIPTION
Updated Readme documentation, The kernel function for UserDefined2ResizeMT is now more simple without +-3 limits of input argument (more 'linear' processing without artificial limits added) to allow to use with 'large' support values up to 10 and more.
I hope I add new param (3rd param) to https://github.com/DTL2020/ResampleMT/blob/9005ebc6a79203333cd690ffae0bba1516ed4258/ResampleMT/resample.cpp#L5068 correctly with 'shifting' old params numbering ?